### PR TITLE
Remove duplicate lines from compatibile template

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-compatible-printer.md
+++ b/.github/ISSUE_TEMPLATE/report-compatible-printer.md
@@ -18,7 +18,6 @@ INSERT TERMINAL OUTPUT HERE
 
 **Verified**: <!-- please mark [x] what you have tested -->
 - [ ] test page printed
-- [ ] test page printed
 - [ ] tested 300dpi
 - [ ] tested 600dpi
 - [ ] tested 1200dpi


### PR DESCRIPTION
The printer compatibility template lists "test page printed" twice