### PR TITLE
Add hl-5370dw support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following printers have been reported to work with this driver:
 * Brother HL-2280DW
 * Brother HL-5030 series
 * Brother HL-5040 series
+* Brother HL-5370DW series
 * Brother HL-L2300D series
 * Brother HL-L2305 series
 * Brother HL-L2310D series

--- a/brlaser.drv.in
+++ b/brlaser.drv.in
@@ -364,6 +364,15 @@ Option "brlaserEconomode/Toner save mode" Boolean AnySetup 10
 }
 
 {
+  ModelName "HL-5370DW series"
+  Attribute "NickName" "" "Brother HL-5370DW series, $USING"
+  Attribute "1284DeviceID" "" "MFG:Brother;CMD:PJL,PCL,PCLXL;MDL:HL-5370DW series;CLS:PRINTER;"
+  Resolution k 1 0 0 0 "300dpi/300 DPI"
+  Duplex normal
+  PCFileName "br5370.ppd"
+}
+
+{
   ModelName "HL-L2300D series"
   Attribute "NickName" "" "Brother HL-L2300D series, $USING"
   Attribute "1284DeviceID" "" "MFG:Brother;CMD:PJL,HBP;MDL:HL-L2300D series;CLS:PRINTER;CID:Brother Laser Type1;"

--- a/brlaser.drv.in
+++ b/brlaser.drv.in
@@ -369,7 +369,7 @@ Option "brlaserEconomode/Toner save mode" Boolean AnySetup 10
   Attribute "1284DeviceID" "" "MFG:Brother;CMD:PJL,PCL,PCLXL;MDL:HL-5370DW series;CLS:PRINTER;"
   Resolution k 1 0 0 0 "300dpi/300 DPI"
   Duplex normal
-  PCFileName "br5370.ppd"
+  PCFileName "br5370d.ppd"
 }
 
 {


### PR DESCRIPTION
**Printer Entry**:
````
Device: uri = usb://Brother/HL-5370DW%20series?serial=C2J486800
        class = direct
        info = Brother HL-5370DW series
        make-and-model = Brother HL-5370DW series
        device-id = MFG:Brother;CMD:PJL,PCL,PCLXL;MDL:HL-5370DW series;CLS:PRINTER;
        location =
````

**Verified**:
- [x] test page printed
- [x] tested 300dpi
- [x] tested 600dpi
- [x] tested 1200dpi
- [x] texted simplex <!-- single-sided printing -->
- [x] tested duplex  <!-- if applicable -->

**Additional notes**:
Contrary to the other printers the duplex directive had to be set to normal to get correct duplex printing to work.