### PR TITLE
Update brlaser version in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(brlaser CXX)
-set(BRLASER_VERSION "6")
+set(BRLASER_VERSION "6.2.7")
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type selected, default to RelWithDebInfo")


### PR DESCRIPTION
This assumes the next release will be 6.2.7.

I'm working on hopefully getting the Debian package for brlaser to be based on this repo, given the old repo being dead.  Having this change released in a simple 6.2.7 release should make the transition easier.