### PR TITLE
Add toner density adjustment option

### DIFF
--- a/brlaser.drv.in
+++ b/brlaser.drv.in
@@ -78,6 +78,20 @@ Option "brlaserEconomode/Toner save mode" Boolean AnySetup 10
   *Choice False/Off "<</cupsInteger10 0>>setpagedevice"
   Choice True/On "<</cupsInteger10 1>>setpagedevice"
 
+Option "brlaserDensityAdjust/Toner Density" PickOne AnySetup 10
+  Choice "94/-6 (lighter)" "<</cupsInteger11 94>>setpagedevice"
+  Choice "95/-5 (lighter)" "<</cupsInteger11 95>>setpagedevice"
+  Choice "96/-4 (lighter)" "<</cupsInteger11 96>>setpagedevice"
+  Choice "97/-3 (lighter)" "<</cupsInteger11 97>>setpagedevice"
+  Choice "98/-2 (lighter)" "<</cupsInteger11 98>>setpagedevice"
+  Choice "99/-1 (lighter)" "<</cupsInteger11 99>>setpagedevice"
+  *Choice 100/Default "<</cupsInteger11 100>>setpagedevice"
+  Choice "101/+1 (darker)" "<</cupsInteger11 101>>setpagedevice"
+  Choice "102/+2 (darker)" "<</cupsInteger11 102>>setpagedevice"
+  Choice "103/+3 (darker)" "<</cupsInteger11 103>>setpagedevice"
+  Choice "104/+4 (darker)" "<</cupsInteger11 104>>setpagedevice"
+  Choice "105/+5 (darker)" "<</cupsInteger11 105>>setpagedevice"
+  Choice "106/+6 (darker)" "<</cupsInteger11 106>>setpagedevice"
 
 {
   ModelName "DCP-1510 series"

--- a/src/job.cc
+++ b/src/job.cc
@@ -69,6 +69,8 @@ void job::write_page_header() {
           page_params_.sourcetray.c_str());
   fprintf(out_, "@PJL SET MEDIATYPE = %s\n",
           page_params_.mediatype.c_str());
+  fprintf(out_, "@PJL SET DENSITY=%d\n", page_params_.density_adjust);
+  fprintf(out_, "@PJL SET DEVBIASADJUST=%d\n", page_params_.density_adjust);
   fprintf(out_, "@PJL SET PAPER = %s\n",
           page_params_.papersize.c_str());
   fprintf(out_, "@PJL SET PAGEPROTECT = AUTO\n");

--- a/src/job.h
+++ b/src/job.h
@@ -29,6 +29,7 @@ struct page_params {
   bool duplex;
   bool tumble;
   bool economode;
+  int density_adjust;
   std::string sourcetray;
   std::string mediatype;
   std::string papersize;
@@ -39,6 +40,7 @@ struct page_params {
       && duplex == o.duplex
       && tumble == o.tumble
       && economode == o.economode
+      && density_adjust == o.density_adjust
       && sourcetray == o.sourcetray
       && mediatype == o.mediatype
       && papersize == o.papersize;

--- a/src/main.cc
+++ b/src/main.cc
@@ -109,6 +109,7 @@ page_params build_page_params(const cups_page_header2_t &header) {
   p.num_copies = header.NumCopies;
   p.resolution = header.HWResolution[0];
   p.economode = header.cupsInteger[10];
+  p.density_adjust = (header.cupsInteger[11] - 100);
   p.mediatype = header.MediaType;
   p.duplex = header.Duplex;
   p.tumble = header.Tumble;


### PR DESCRIPTION
I just got a brand new HL-1110, and when printing text set in a serif font, the print quality looked like ass. I found a toner density adjustment in the Windows driver, and after some USB capture and comparison with some PPDs from brother's drivers for other brother printers I added an adjustment to this driver.

Here's one of brother's PPDs for another printer with the same setting:
https://github.com/pathakh/brotherCups/blob/552710c340ebb4c9b54fd0753134e34973a26d24/brother/ppd/BRP7000E_GPL.PPD#L447

...and here's the PJL header of a print job that has the density set to +3 (darker) as sent by brother's latest (five year old) Windows driver:
```
·%-12345X@PJL 
@PJL SET REPRINT=OFF
@PJL SET HOLD=OFF
@PJL SET USERNAME="jaseg" 
@PJL SET JOBNAME="Developing non-interactive MPC with trusted hardware for enhanced security" 
@PJL JOB NAME="Developing non-interactive MPC with trusted hardware for enhanced security" 
@PJL PRINTLOG ITEM = 1,PRINTER
@PJL PRINTLOG ITEM = 2,Wed,21 Feb 2024 18:15:09
@PJL PRINTLOG ITEM = 3,jaseg
@PJL PRINTLOG ITEM = 4,BIGDATA
@PJL SET JOBTIME = "20240221181509" 
@PJL SET STRINGCODESET=HPROMAN8
@PJL SET ECONOMODE=OFF
@PJL SET MEDIATYPE=REGULAR
@PJL SET DENSITY=3
@PJL SET DEVBIASADJUST=3
@PJL SET LESSPAPERCURL=OFF
@PJL SET FIXINTENSITYUP=OFF
@PJL SET TRANSFERLEVELUP=ON
@PJL SET TRANSFERLEVEL=0
@PJL SET RESOLUTION=600
@PJL SET HQMMODE=OFF
@PJL ENTER LANGUAGE=PCL
```