### PR TITLE
Fixes #40 - Update min CMake version allowed by CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(Owl-Maintain/brlaser CXX)
 set(BRLASER_VERSION "6.2.7")
 


### PR DESCRIPTION
As per the following documentation, CMake 4.0 does not allow using a minimum CMake version below 3.5.

[](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html)

As of today, the CMake version in Arch Linux is 4.0.1, and I was also seeing the same build failure message described in issue #40. Tested and confirmed that this change allowed the brlaser package to build successfully.